### PR TITLE
Merge EKS private cluster branch + fixes

### DIFF
--- a/aws-infra-terraform/ec2.tf
+++ b/aws-infra-terraform/ec2.tf
@@ -9,8 +9,9 @@ module "ubuntu-tailscale-client" {
   source           = "./modules/cloudinit-ts"
   hostname         = var.hostname
   accept_routes    = true
+  advertise_routes = local.advertise_routes
   ephemeral        = true
-  primary_tag      = "k8s-operator"
+  primary_tag      = "subnet-router"
   additional_parts = [
     {
       filename     = "install_docker.sh"

--- a/aws-infra-terraform/ec2.tf
+++ b/aws-infra-terraform/ec2.tf
@@ -10,7 +10,7 @@ module "ubuntu-tailscale-client" {
   hostname         = var.hostname
   accept_routes    = true
   advertise_routes = local.advertise_routes
-  ephemeral        = true
+  ephemeral        = false
   primary_tag      = "subnet-router"
   additional_parts = [
     {

--- a/aws-infra-terraform/ec2.tf
+++ b/aws-infra-terraform/ec2.tf
@@ -48,7 +48,15 @@ resource "aws_security_group" "main" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-    description = "Allow SSH access" # Using key-based access anyway, but again we don't do this in prod.
+    description = "Allow SSH access"
+  }
+
+  ingress {
+    from_port   = 41641
+    to_port     = 41641
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow Tailscale WG direct connection access"
   }
 
   egress {
@@ -60,7 +68,7 @@ resource "aws_security_group" "main" {
   }
 }
 
-# Provision the EC2 instance,pass in templatized base64-encoded cloudinit data from the module that sets up TS, and install nginx container
+# Provision the EC2 instance,pass in templatized base64-encoded cloudinit data from the module that sets up Tailscale client and Docker
 resource "aws_instance" "client" {
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t3.micro"
@@ -100,7 +108,7 @@ resource "aws_instance" "client" {
   connection {
     type        = "ssh"
     user        = "ubuntu"
-    private_key = file("~/.ssh/${local.key_name}.pem") # User needs put their private key in ~/.ssh (for now)
+    private_key = file("~/.ssh/${local.key_name}")
     host        = self.public_ip
   }
 }

--- a/aws-infra-terraform/eks.tf
+++ b/aws-infra-terraform/eks.tf
@@ -17,15 +17,19 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 20.0"
 
-  cluster_name                   = local.name
-  cluster_version                = local.cluster_version
-  cluster_endpoint_public_access = true
-  enable_cluster_creator_admin_permissions = true # Just for this PoC, we never do this in prod. Right?
+  cluster_name                    = local.name
+  cluster_version                 = local.cluster_version
+  cluster_endpoint_public_access  = false
+  cluster_endpoint_private_access = true
+
+  enable_cluster_creator_admin_permissions = true
   
   cluster_addons = {
     coredns                = {}
     kube-proxy             = {}
-    vpc-cni                = {}
+    vpc-cni                = {
+      pod_cidr = local.cluster_pod_ipv4_cidr
+    }
     metrics-server         = {}   
   }
 

--- a/aws-infra-terraform/eks.tf
+++ b/aws-infra-terraform/eks.tf
@@ -10,6 +10,11 @@ provider "aws" {
 # Get list of available AZs in our region
 data "aws_availability_zones" "available" {}
 
+# Cluster auth datasource
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
 ################################################################################
 # EKS Cluster                                                                  #
 ################################################################################

--- a/aws-infra-terraform/eks.tf
+++ b/aws-infra-terraform/eks.tf
@@ -118,6 +118,7 @@ resource "tailscale_dns_split_nameservers" "aws_route53_resolver" {
 
 resource "tailscale_dns_search_paths" "eks_search_paths" {
   search_paths = [
-    "eks.amazonaws.com"
+    "eks.amazonaws.com",
+    "svc.cluster.local"
   ]
 }

--- a/aws-infra-terraform/locals.tf
+++ b/aws-infra-terraform/locals.tf
@@ -6,7 +6,6 @@ locals {
   name                      = var.name
   region                    = var.region
   vpc_cidr                  = var.vpc_cidr
-  cluster_pod_ipv4_cidr     = var.cluster_pod_ipv4_cidr
   cluster_service_ipv4_cidr = var.cluster_service_ipv4_cidr
   desired_size              = var.desired_size
   key_name                  = var.ssh_keyname
@@ -14,10 +13,14 @@ locals {
   oauth_client_id           = var.oauth_client_id
   oauth_client_secret       = var.oauth_client_secret
   tags                      = var.tags
-  # Not too happy w/the logic below on slicing the subnets, but c'est la vie.
+  # Select the first 3 availability zones from the available list of AWS AZs. If <3 are available, select them all
   azs                       = slice(data.aws_availability_zones.available.names, 0, min(length(data.aws_availability_zones.available.names), 3))
+  # Generate a list of subnets off the VPC CIDR with one public subnet generated per AZ 
   public_subnets            = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]    
+  # Generate a list of subnets off the VPC CIDR with one private subnet per AZ with an offset
   private_subnets           = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k + 10)]
-  # Merge EKS private subnets with user-defined advertise_routes (if any)
-  advertise_routes          = distinct(concat(local.private_subnets, var.advertise_routes))
+  # AWS Route 53 Resolver VPC+2 IP 
+  vpc_plus_2_ip             = "${join(".", slice(split(".", var.vpc_cidr), 0, 3))}.2"
+  # Merge EKS private subnets CIDRs, AWS Route 53 Resolver IP, and any user-defined routes and advertise them from the subnet router
+  advertise_routes          = distinct(concat(local.private_subnets, coalesce(var.advertise_routes, []), ["${local.vpc_plus_2_ip}/32"]))
 }

--- a/aws-infra-terraform/locals.tf
+++ b/aws-infra-terraform/locals.tf
@@ -6,6 +6,7 @@ locals {
   name                      = var.name
   region                    = var.region
   vpc_cidr                  = var.vpc_cidr
+  cluster_pod_ipv4_cidr     = var.cluster_pod_ipv4_cidr
   cluster_service_ipv4_cidr = var.cluster_service_ipv4_cidr
   desired_size              = var.desired_size
   key_name                  = var.ssh_keyname
@@ -17,4 +18,6 @@ locals {
   azs                       = slice(data.aws_availability_zones.available.names, 0, min(length(data.aws_availability_zones.available.names), 3))
   public_subnets            = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]    
   private_subnets           = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k + 10)]
+  # Merge EKS private subnets with user-defined advertise_routes (if any)
+  advertise_routes          = distinct(concat(local.private_subnets, var.advertise_routes))
 }

--- a/aws-infra-terraform/outputs.tf
+++ b/aws-infra-terraform/outputs.tf
@@ -66,7 +66,7 @@ Next Steps:
    aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name} --alias ${module.eks.cluster_name}
 
 2. Test SSH to the EC2 instance's public IP:
-   ssh -i ~/.ssh/${local.key_name}.pem ubuntu@${aws_instance.client.public_ip}
+   ssh -i ~/.ssh/${local.key_name} ubuntu@${aws_instance.client.public_ip}
 
 Happy deploying <3
 EOT

--- a/aws-infra-terraform/terraform.tfvars.example
+++ b/aws-infra-terraform/terraform.tfvars.example
@@ -18,7 +18,7 @@ hostname = "my-ubuntu-client"
 ################################################################################
 # Common User Vars reqd. for all Cluster Instances and client EC2 Instance     #
 ################################################################################
-ssh_keyname = "my-aws-keypair-name"
+ssh_keyname = "my-aws-keypair-name.pem"
 #tags = {
 #  "Environment" = "Test"
 #  "Owner"       = "MeMyselfandI"

--- a/aws-infra-terraform/variables.tf
+++ b/aws-infra-terraform/variables.tf
@@ -31,6 +31,12 @@ variable "cluster_service_ipv4_cidr" {
   default     = "10.40.0.0/16"
 }
 
+variable "cluster_pod_ipv4_cidr" {
+  description = "The CIDR block to use for pod IP addresses."
+  type        = string
+  default     = "10.100.0.0/18"
+}
+
 variable "cluster_version" {
   description = "Kubernetes version for this cluster"
   type        = string
@@ -66,4 +72,10 @@ variable "oauth_client_secret" {
 variable "hostname" {
   description = "Tailscale Machine hostname of the EC2 instance"
   type        = string
+}
+
+variable "advertise_routes" {
+  description = "List of CIDR blocks to advertise via Tailscale in addition to the EKS private subnets"
+  type        = list(string)
+  default     = []  # Default to an empty list if not set
 }

--- a/aws-infra-terraform/variables.tf
+++ b/aws-infra-terraform/variables.tf
@@ -77,5 +77,5 @@ variable "hostname" {
 variable "advertise_routes" {
   description = "List of CIDR blocks to advertise via Tailscale in addition to the EKS private subnets"
   type        = list(string)
-  default     = []  # Default to an empty list if not set
+  default     = []
 }

--- a/k8s-docker-terraform/k8s.tf
+++ b/k8s-docker-terraform/k8s.tf
@@ -46,6 +46,9 @@ resource "helm_release" "tailscale_operator" {
         clientId     = local.oauth_client_id
         clientSecret = local.oauth_client_secret
       }
+      apiServerProxyConfig = {
+        mode = "true"
+      }
     })
   ] 
 }

--- a/k8s-docker-terraform/k8s.tf
+++ b/k8s-docker-terraform/k8s.tf
@@ -126,9 +126,3 @@ resource "tailscale_dns_split_nameservers" "coredns_split_nameservers" {
   domain      = "svc.cluster.local"
   nameservers = [data.kubernetes_service.kubedns.spec[0].cluster_ip]
 }
-
-resource "tailscale_dns_search_paths" "coredns_search_paths" {
-  search_paths = [
-    "svc.cluster.local"
-  ]
-}

--- a/k8s-docker-terraform/k8s.tf
+++ b/k8s-docker-terraform/k8s.tf
@@ -57,7 +57,7 @@ data "kubectl_path_documents" "docs" {
   pattern = "../manifests/*.yaml"
 }
 
-# Deploy nginx in the cluster 
+# Deploy all manifests into the cluster 
 resource "kubectl_manifest" "app_manifests" {
   for_each  = data.kubectl_path_documents.docs.manifests
   yaml_body = each.value
@@ -125,4 +125,10 @@ data "kubernetes_service" "kubedns" {
 resource "tailscale_dns_split_nameservers" "coredns_split_nameservers" {
   domain      = "svc.cluster.local"
   nameservers = [data.kubernetes_service.kubedns.spec[0].cluster_ip]
+}
+
+resource "tailscale_dns_search_paths" "coredns_search_paths" {
+  search_paths = [
+    "svc.cluster.local"
+  ]
 }

--- a/k8s-docker-terraform/locals.tf
+++ b/k8s-docker-terraform/locals.tf
@@ -19,7 +19,7 @@ locals {
   key_name                      = data.terraform_remote_state.aws_tfstate.outputs.ssh_keyname
   aws_instance_client_public_ip = data.terraform_remote_state.aws_tfstate.outputs.client_public_ip
   eks_cluster_endpoint          = data.terraform_remote_state.aws_tfstate.outputs.eks_cluster_endpoint
-  eks_cluster_ca_certificate    = base64decode(data.terraform_remote_state.aws_tfstate.outputs.eks_cluster_ca_certificate)
+  eks_cluster_ca_certificate     = base64decode(data.terraform_remote_state.aws_tfstate.outputs.eks_cluster_ca_certificate)
   eks_cluster_auth_token        = data.aws_eks_cluster_auth.this.token
   oauth_client_id               = data.terraform_remote_state.aws_tfstate.outputs.oauth_client_id
   oauth_client_secret           = data.terraform_remote_state.aws_tfstate.outputs.oauth_client_secret

--- a/sections/section-3.1-inputs.md
+++ b/sections/section-3.1-inputs.md
@@ -9,7 +9,6 @@
 | hostname | Tailscale Machine hostname of the EC2 instance | `string` | N/A | Yes |
 | key_name | SSH Keypair name that already exists in your region in AWS, used to access EKS worker nodes and EC2 instance | `string` | N/A | Yes |
 | cluster_version | Kubernetes version | `string` | "1.31" | No |
-| cluster_pod_ipv4_cidr | Kubernetes `Pod` CIDR range | `string` | "10.100.0.0/18" | No |
 | cluster_service_ipv4_cidr | Kubernetes `Service` CIDR range | `string` | "10.40.0.0/16" | No |
 | desired_size | Desired no. of EKS worker nodes | `string` | "2" | No |
 | vpc_cidr | AWS VPC CIDR for EKS cluster and EC2 instance | `string` | "10.0.0.0/16" | No |

--- a/sections/section-3.1-inputs.md
+++ b/sections/section-3.1-inputs.md
@@ -9,6 +9,7 @@
 | hostname | Tailscale Machine hostname of the EC2 instance | `string` | N/A | Yes |
 | key_name | SSH Keypair name that already exists in your region in AWS, used to access EKS worker nodes and EC2 instance | `string` | N/A | Yes |
 | cluster_version | Kubernetes version | `string` | "1.31" | No |
+| cluster_pod_ipv4_cidr | Kubernetes `Pod` CIDR range | `string` | "10.100.0.0/18" | No |
 | cluster_service_ipv4_cidr | Kubernetes `Service` CIDR range | `string` | "10.40.0.0/16" | No |
 | desired_size | Desired no. of EKS worker nodes | `string` | "2" | No |
 | vpc_cidr | AWS VPC CIDR for EKS cluster and EC2 instance | `string` | "10.0.0.0/16" | No |


### PR DESCRIPTION
Changelog: 

- No more public control plane
- Subnet router EC2 instance advertises correct routes and its SG can now send traffic to the EKS control plane SG thus allowing kubectl access
- Misc fixes
- Add K8s apiserver proxy to operator Helm

TODO: 
- Docs/sections need to be updated